### PR TITLE
Add unit tests for repo_crawler.py using pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ You can run the tool with `uv`. Currently, this prints all public, non-forked re
 ```bash
 uv run orgwarden <github-org-name>
 ```
+
+## Development
+To manually run tests on this project, run the following command:
+```bash
+uv run pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,8 @@ orgwarden = "orgwarden.__main__:app"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+]

--- a/src/orgwarden/test_repo_crawler.py
+++ b/src/orgwarden/test_repo_crawler.py
@@ -1,0 +1,72 @@
+import pytest
+import requests
+from .repo_crawler import Repository, fetch_org_repos
+
+class TestFetchOrgRepos():
+    def test_no_org_name(self):
+        with pytest.raises(TypeError):
+            fetch_org_repos()
+
+    def test_non_existing_org(self):
+        with pytest.raises(requests.RequestException):
+            fetch_org_repos("")
+
+    def test_gt_sse_center(self):
+        SSEC = "gt-sse-center"
+        KNOWN_REPOS = [
+            "RepoAuditor",
+            "PatientX.AI",
+            "PythonProjectBootstrapper"
+        ]
+        repos = fetch_org_repos(SSEC)
+        assert no_duplicates(repos)
+        assert includes_known_repos(repos, KNOWN_REPOS)
+        # ensure repos excludes .github and forks
+        assert not includes_known_repos(repos, [".github"])
+        assert not includes_known_repos(repos, ["LIReC"])
+
+    def test_gt_tech_ai(self):
+        TECH_AI = "gt-tech-ai"
+        KNOWN_REPOS = [] # currently no public repos
+        repos = fetch_org_repos(TECH_AI)
+        assert no_duplicates(repos)
+        assert includes_known_repos(repos, KNOWN_REPOS)
+
+
+def no_duplicates(repos: list[Repository]) -> bool:
+    unique = []
+    for repo in repos:
+        if repo in unique:
+            return False
+        unique.append(repo)
+    return True
+
+def test_no_duplicates():
+    assert no_duplicates([
+        Repository("test_repo_1", "https://example.com/test1", "test_org_1"),
+        Repository("test_repo_2", "https://example.com/test2", "test_org_2")
+    ])
+    assert not no_duplicates([
+        Repository("test_repo_1", "https://example.com/test1", "test_org_1"),
+        Repository("test_repo_1", "https://example.com/test1", "test_org_1")
+    ])
+
+def includes_known_repos(repos: list[Repository], known_repos_names: list[str]) -> bool:
+    actual_names = []
+    for repo in repos:
+        actual_names.append(repo.name)
+    for known_name in known_repos_names:
+        if known_name not in actual_names:
+            return False
+    return True
+
+def test_includes_known_repos():
+    assert includes_known_repos(
+        [Repository("test_repo_1", "https://example.com/test1", "test_org_1")],
+        ["test_repo_1"]
+    )
+    assert not includes_known_repos(
+        [Repository("test_repo_1", "https://example.com/test1", "test_org_1")],
+        ["test_repo_2"]
+    )
+

--- a/uv.lock
+++ b/uv.lock
@@ -77,6 +77,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -106,10 +115,36 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "requests", specifier = ">=2.32.3" },
     { name = "typer", specifier = ">=0.15.2" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3.5" }]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
 ]
 
 [[package]]
@@ -119,6 +154,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Added unit tests for repo_crawler.py
- ensures repo-fetching only works with valid GitHub org names
- ensures fetched repos for gt-sse-center include a few known repos, are unique, and do not include forks
- ensures fetching repos for gt-tech-ai does not fail, but does not check for known repos as there are currently no public repos
- includes tests for helper functions

*Also setup commit signing*