### PR TITLE
Feature: Integrate RepoAuditor via audit command

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,11 +26,13 @@ jobs:
       - name: Install Dependencies
         run: uv sync --frozen
 
-      - name: Run Tests
-        run: uv run pytest
-
       - name: Validate Formatting
         run: uv run ruff format --check --verbose
 
       - name: Validate Linting
         run: uv run ruff check --verbose
+        
+      - name: Run Tests
+        run: uv run pytest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 👮‍♀️ OrgWarden (Work In Progress)
 
-*OrgWarden* is a tool for auditing an oganization's repositories.
+*OrgWarden* helps ensure your GitHub organization's repositories follow best practices. Under the hood, OrgWarden uses [RepoAuditor](https://github.com/gt-sse-center/RepoAuditor).
 
 ## Installation
 
@@ -19,11 +19,20 @@ uv sync
 ```
 
 ## Usage
-You can run the tool with `uv`. Currently, this prints all public, non-forked repositories for the specified github organization. In the future, the ability to run audits on each repository will be implemented.
+You can run the tool with `uv`. The available commands are as follows:
 
+### List Repositories
+Lists all public, non-forked repositories for the specified GitHub organization.
 ```bash
-uv run orgwarden <github-org-name>
+uv run orgwarden list-repos <org_url>
 ```
+
+### Audit
+Runs [RepoAuditor](https://github.com/gt-sse-center/RepoAuditor) tooling. If the provided url points to a GitHub repository, RepoAuditor will run against said repository. If the provided url points to a GitHub organization, RepoAuditor will run against all public, non-forked repositories within said organization. 
+```bash
+uv run orgwarden audit <repo_or_org_url>
+```
+
 
 ## Development
 To manually run tests on this project, run the following command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "requests>=2.32.3",
+    "repoauditor>=0.1.22",
     "typer>=0.15.2",
 ]
 

--- a/src/orgwarden/__main__.py
+++ b/src/orgwarden/__main__.py
@@ -1,16 +1,115 @@
+import sys
+from typing import Annotated
 import typer
-from .repo_crawler import fetch_org_repos
+from orgwarden.audit import audit_repository
+from orgwarden.repository import Repository
+from orgwarden.repo_crawler import fetch_org_repos
+from orgwarden.url_tools import validate_url
 
 app = typer.Typer()
 
 
 @app.command()
-def main(org_name: str) -> None:
-    repos = fetch_org_repos(org_name)
+def list_repos(
+    url: Annotated[
+        str,
+        typer.Argument(
+            help="The url of a GitHub organization. Ex: 'https://github.com/gt-tech-ai'"
+        ),
+    ],
+) -> None:
+    """
+    Lists all public, non-forked repositories for the specified organization.
+    """
 
-    print(f"~~~~~ Public repositories found for {org_name} ~~~~~")
+    try:
+        parsed_url = validate_url(url)
+    except ValueError:
+        print_invalid_url_msg(url)
+        sys.exit(1)
+
+    try:
+        repos = fetch_org_repos(parsed_url.org_name, parsed_url.hostname)
+    except FileNotFoundError:
+        print_gh_not_installed()
+        sys.exit(1)
+    except Exception as e:
+        print(e)
+        sys.exit(1)
+
+    print(f"~~~~~ Public repositories found for {url} ~~~~~")
     for repo in repos:
         print(f"{repo.org}/{repo.name} - {repo.url}")
+
+
+@app.command()
+def audit(
+    url: Annotated[
+        str, typer.Argument(help="The url for a GitHub repository or organization.")
+    ],
+) -> None:
+    """
+    If the provided <url> is a repository, runs RepoAuditor against the specified repository.
+    If the provided <url> is an organization, runs RepoAuditor against all of the organization's public, non-forked repositories.
+    """
+
+    try:
+        parsed_url = validate_url(url)
+    except ValueError:
+        print_invalid_url_msg(url)
+        sys.exit(1)
+
+    if parsed_url.repo_name:  # repository
+        repo = Repository(
+            name=parsed_url.repo_name,
+            url=url,
+            org=parsed_url.org_name,
+        )
+        exit_code, _ = audit_repository(repo)
+        sys.exit(exit_code)
+
+    else:  # organization
+        try:
+            repos = fetch_org_repos(parsed_url.org_name, parsed_url.hostname)
+        except FileNotFoundError:
+            print_gh_not_installed()
+            sys.exit(1)
+        except Exception as e:
+            print(e)
+            sys.exit(1)
+
+        final_exit_code = 0  # keep track of highest exit code i.e. worst error -> ensures the command fails if any repo fails audit
+        for repo in repos:
+            exit_code, _ = audit_repository(repo)
+            final_exit_code = max(final_exit_code, exit_code)
+        sys.exit(final_exit_code)
+
+
+# pragma: no cover
+def print_invalid_url_msg(url: str):
+    typer.echo(
+        typer.style(
+            f"Error: {url} is invalid.",
+            fg=typer.colors.RED,
+        )
+    )
+    typer.echo(
+        typer.style(
+            "Example: https://github.com/gt-tech-ai/OrgWarden",
+            fg=typer.colors.GREEN,
+        )
+    )
+
+
+# pragma: no cover
+def print_gh_not_installed():
+    typer.echo(typer.style("The GitHub CLI is not installed.", fg=typer.colors.RED))
+    typer.echo(
+        typer.style(
+            "Please follow the installation instructions here: https://github.com/cli/cli#installation",
+            fg=typer.colors.CYAN,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/src/orgwarden/audit.py
+++ b/src/orgwarden/audit.py
@@ -1,0 +1,15 @@
+import subprocess
+from orgwarden.repo_crawler import Repository
+
+
+def audit_repository(repo: Repository, capture: bool = False) -> tuple[int, str | None]:
+    """
+    Runs RepoAuditor against the specified repository and returns a tuple containing the exit code and the stdout if `capture` is set to True.
+    """
+    audit_res = subprocess.run(
+        f"uv run repo_auditor --include GitHub --GitHub-url {repo.url}",
+        shell=True,
+        capture_output=capture,
+        text=True,
+    )
+    return audit_res.returncode, audit_res.stdout if capture else None

--- a/src/orgwarden/repo_crawler.py
+++ b/src/orgwarden/repo_crawler.py
@@ -1,44 +1,44 @@
-from dataclasses import dataclass
-import requests
+import json
+import shutil
+import subprocess
+from orgwarden.repository import Repository
 
 
-@dataclass
-class Repository:
-    name: str
-    url: str
-    org: str
+class APIError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
 
 
-def fetch_org_repos(org_name: str) -> list[Repository]:
+def fetch_org_repos(org_name: str, hostname: str) -> list[Repository]:
     """
     Returns a `Repository` list containing the specified organization's public, non-forked repositories.
+    Raises an `APIError` if an error occurs while fetching repositories.
+    Raises a `FileNotFoundError` if the GitHub CLI is not installed.
     """
 
-    org_repo_entries: list[dict] = []  # unfiltered api response
-    page_num = 1
-    while True:
-        response = requests.get(
-            url=f"https://api.github.com/orgs/{org_name}/repos",
-            headers={"Accept": "application/vnd.github+json"},
-            params={
-                "per_page": 100,  # max repos per page
-                "page": page_num,
-            },
-        )
-        if not response or response.status_code != 200:
-            raise requests.HTTPError(
-                f"Error fetching repos for organization: {org_name}", response=response
-            )
+    # check if gh cli is installed
+    if shutil.which("gh") is None:
+        raise FileNotFoundError("GitHub CLI is not installed.")
 
-        json_data: list[dict] = response.json()
-        if not json_data:
-            break  # No more repos
-        org_repo_entries += json_data
-        page_num += 1  # Go to the next page
+    org_repo_entries: list[dict] = []  # unfiltered api response
+
+    res = subprocess.run(
+        f"gh api orgs/{org_name}/repos --hostname {hostname} --paginate",
+        shell=True,
+        capture_output=True,
+    )
+    if res.stderr:
+        raise APIError(f"Error fetching repos for {org_name}: {res.stderr}")
+
+    org_repo_entries = json.loads(res.stdout)
+    if not isinstance(org_repo_entries, list):
+        raise APIError("API JSON response does not match expected schema")
 
     # Build filtered list of Repositories
     repositories: list[Repository] = []
     for repo_entry in org_repo_entries:
+        if repo_entry["private"]:
+            continue  # do not include private repositories (for now?)
         if repo_entry["name"] == ".github":
             continue  # ignore config repo
         if repo_entry["fork"]:

--- a/src/orgwarden/repository.py
+++ b/src/orgwarden/repository.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Repository:
+    name: str
+    url: str
+    org: str

--- a/src/orgwarden/url_tools.py
+++ b/src/orgwarden/url_tools.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+@dataclass
+class ParsedURL:
+    hostname: str
+    org_name: str
+    repo_name: str | None
+
+
+def validate_url(url: str) -> ParsedURL:
+    """
+    Validates the provided url.
+    Returns a `ParsedURL` object if the url is valid.
+    Raises a ValueError if the url is invalid.
+    """
+
+    parsed_url = urlparse(url)
+    if not parsed_url.scheme or not parsed_url.netloc:
+        raise ValueError()
+
+    split_path = parsed_url.path.strip("/").split("/")
+    if len(split_path) != 1 and len(split_path) != 2:
+        raise ValueError()
+
+    return ParsedURL(
+        hostname=parsed_url.netloc,
+        org_name=split_path[0],
+        repo_name=split_path[1] if len(split_path) == 2 else None,
+    )

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,8 @@
+ORGWARDEN_REPO_NAME = "OrgWarden"
+ORGWARDEN_URL = "https://github.com/gt-tech-ai/OrgWarden"
+TECH_AI_URL = "https://github.com/gt-tech-ai"
+TECH_AI_ORG_NAME = "gt-tech-ai"
+GITHUB_HOSTNAME = "github.com"
+TECH_AI_KNOWN_REPOS = [ORGWARDEN_REPO_NAME]
+
+SELF_HOSTED_HOSTNAME = "github.gatech.edu"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,32 @@
+from orgwarden.audit import audit_repository
+import pytest
+
+from orgwarden.repository import Repository
+from tests.constants import ORGWARDEN_REPO_NAME, TECH_AI_ORG_NAME
+
+
+def test_no_repository():
+    with pytest.raises(TypeError):
+        audit_repository()
+
+
+def test_invalid_repository():
+    exit_code, stdout = audit_repository(
+        Repository(name="invalid-repo", url="https://example.com", org="invalid-org"),
+        capture=True,
+    )
+    assert exit_code != 0
+    assert "not a valid GitHub repository" in stdout
+
+
+def test_orgwarden_repo():
+    repo = Repository(
+        name=ORGWARDEN_REPO_NAME,
+        url=f"https://github.com/{TECH_AI_ORG_NAME}/{ORGWARDEN_REPO_NAME}",
+        org=TECH_AI_ORG_NAME,
+    )
+    _, stdout = audit_repository(repo, capture=True)
+    # cannot check exit_code, as this is dependent on whether OrgWarden passes audit
+    assert "Results: DONE!" in stdout
+    assert repo.url in stdout
+    assert "not a valid GitHub repository" not in stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,23 +1,143 @@
+from pytest import MonkeyPatch
 from typer.testing import CliRunner
 from orgwarden.__main__ import app
-from .test_repo_crawler import TECH_AI_ORG_NAME, TECH_AI_KNOWN_REPOS
+from orgwarden.repository import Repository
+from tests.constants import (
+    ORGWARDEN_REPO_NAME,
+    ORGWARDEN_URL,
+    TECH_AI_KNOWN_REPOS,
+    TECH_AI_ORG_NAME,
+    TECH_AI_URL,
+    GITHUB_HOSTNAME,
+)
 
 runner = CliRunner()
 
 
-class TestApp:
-    def test_invalid_org(self):
-        res = runner.invoke(app, [""])
+class TestListReposCommand:
+    COMMAND = "list-repos"
+
+    def test_invalid_orgs(self):
+        INVALID_URLS = ["", "example.com", "https://github.com"]
+        for org in INVALID_URLS:
+            res = runner.invoke(app, [self.COMMAND, org])
+            assert res.exit_code != 0
+
+    def test_valid_orgs(self):
+        VALID_URLS = [TECH_AI_URL]
+        for org in VALID_URLS:
+            res = runner.invoke(app, [self.COMMAND, org])
+            assert res.exit_code == 0
+            assert all([repo_name in res.stdout for repo_name in TECH_AI_KNOWN_REPOS])
+
+    def test_gh_not_installed(self, monkeypatch: MonkeyPatch):
+        mock_which_called = False
+
+        def mock_which(cmd: str) -> str | None:
+            nonlocal mock_which_called
+            mock_which_called = True
+            assert cmd == "gh"
+            return None
+
+        monkeypatch.setattr("shutil.which", mock_which)
+        res = runner.invoke(app, [self.COMMAND, TECH_AI_URL])
         assert res.exit_code != 0
+        assert "GitHub CLI is not installed" in res.stdout
+        assert mock_which_called
 
-    def test_tech_ai(self):
-        res = runner.invoke(app, [TECH_AI_ORG_NAME])
+
+class TestAuditCommand:
+    COMMAND = "audit"
+
+    def test_invalid_urls(self):
+        INVALID_URLS = [
+            "",  # empty url
+            "/gt-tech-ai/OrgWarden",  # missing site
+            "github.com/gt-tech-ai/OrgWarden",  # missing protocol
+            "https://github.com/gt-tech-ai/OrgWarden/extra-bits",  # path too long
+        ]
+        for url in INVALID_URLS:
+            res = runner.invoke(app, [self.COMMAND, url])
+            assert res.exit_code != 0
+            assert f"{url} is invalid" in res.stdout
+
+    def test_gh_not_installed(self, monkeypatch: MonkeyPatch):
+        mock_which_called = False
+
+        def mock_which(cmd: str) -> str | None:
+            nonlocal mock_which_called
+            mock_which_called = True
+            assert cmd == "gh"
+            return None
+
+        monkeypatch.setattr("shutil.which", mock_which)
+        res = runner.invoke(app, [self.COMMAND, TECH_AI_URL])
+        assert res.exit_code != 0
+        assert "GitHub CLI is not installed" in res.stdout
+        assert mock_which_called
+
+    def test_audit_with_repo_url(self, monkeypatch: MonkeyPatch):
+        """
+        Ensures that `audit` command correctly parses url argument and passes correct `Repository` object to `audit_repository`.
+        """
+        mock_audit_repository_called = False
+
+        def mock_audit_repository(
+            repo: Repository, capture: bool = False
+        ) -> tuple[int, str | None]:
+            nonlocal mock_audit_repository_called
+            mock_audit_repository_called = True
+            assert not capture
+            assert repo.url == ORGWARDEN_URL
+            assert repo.name == ORGWARDEN_REPO_NAME
+            assert repo.org == TECH_AI_ORG_NAME
+            return 0, None
+
+        monkeypatch.setattr(
+            "orgwarden.__main__.audit_repository", mock_audit_repository
+        )
+
+        res = runner.invoke(app, [self.COMMAND, ORGWARDEN_URL])
+        assert mock_audit_repository_called
         assert res.exit_code == 0
-        assert includes_known_repos(res.stdout, TECH_AI_KNOWN_REPOS)
 
+    def test_audit_with_org_url(self, monkeypatch: MonkeyPatch):
+        """
+        Ensures that `audit` command correctly parses url argument, runs `fetch_org_repos` on the given org, and runs audit `audit_repository` for each returned repository.
+        """
+        mock_repos = [
+            Repository(name="repo1", url="url1", org=TECH_AI_ORG_NAME),
+            Repository(name="repo2", url="url2", org=TECH_AI_ORG_NAME),
+            Repository(name="repo3", url="url3", org=TECH_AI_ORG_NAME),
+        ]
 
-def includes_known_repos(stdout: str, repo_names: list[str]) -> bool:
-    for repo_name in repo_names:
-        if repo_name not in stdout:
-            return False
-    return True
+        mock_fetch_org_repos_called = False
+
+        def mock_fetch_org_repos(org_name: str, hostname: str) -> list[Repository]:
+            nonlocal mock_fetch_org_repos_called
+            mock_fetch_org_repos_called = True
+            assert org_name == TECH_AI_ORG_NAME
+            assert hostname == GITHUB_HOSTNAME
+            return mock_repos
+
+        monkeypatch.setattr("orgwarden.__main__.fetch_org_repos", mock_fetch_org_repos)
+
+        mock_audit_repository_calls = 0
+
+        def mock_audit_repository(
+            repo: Repository, capture: bool = False
+        ) -> tuple[int, str | None]:
+            nonlocal mock_audit_repository_calls
+            mock_audit_repository_calls += 1
+            assert not capture
+            assert repo.org == TECH_AI_ORG_NAME
+            return 0, None
+
+        monkeypatch.setattr(
+            "orgwarden.__main__.audit_repository", mock_audit_repository
+        )
+
+        res = runner.invoke(app, [self.COMMAND, TECH_AI_URL])
+        assert mock_fetch_org_repos_called
+        assert mock_audit_repository_calls == len(mock_repos)
+        assert res.exit_code == 0

--- a/tests/test_repo_crawler.py
+++ b/tests/test_repo_crawler.py
@@ -1,70 +1,89 @@
 import pytest
-import requests
-from orgwarden.repo_crawler import Repository, fetch_org_repos
-
-TECH_AI_ORG_NAME = "gt-tech-ai"
-TECH_AI_KNOWN_REPOS = ["OrgWarden"]
-
-
-class TestFetchOrgRepos:
-    def test_no_org_name(self):
-        with pytest.raises(TypeError):
-            fetch_org_repos()
-
-    def test_non_existing_org(self):
-        with pytest.raises(requests.HTTPError):
-            fetch_org_repos("")
-
-    def test_gt_tech_ai(self):
-        repos = fetch_org_repos(TECH_AI_ORG_NAME)
-        assert no_duplicates(repos)
-        assert includes_known_repos(repos, TECH_AI_KNOWN_REPOS)
-        # ensure repos excludes .github
-        assert not includes_known_repos(repos, [".github"])
-        # ensure repos excludes forks - gt-tech-ai currently has no public forks, ignore for now
-        # assert not includes_known_repos(repos, [""])
+from pytest import MonkeyPatch
+from orgwarden.repo_crawler import APIError, fetch_org_repos
+from orgwarden.repository import Repository
+from tests.constants import (
+    SELF_HOSTED_HOSTNAME,
+    TECH_AI_KNOWN_REPOS,
+    TECH_AI_ORG_NAME,
+    GITHUB_HOSTNAME,
+)
 
 
-def no_duplicates(repos: list[Repository]) -> bool:
+def test_no_org_name():
+    with pytest.raises(TypeError):
+        fetch_org_repos()
+
+
+def test_missing_org():
+    with pytest.raises(APIError):
+        fetch_org_repos("", GITHUB_HOSTNAME)
+
+
+def test_missing_hostname():
+    with pytest.raises(APIError):
+        fetch_org_repos(TECH_AI_ORG_NAME, "")
+
+
+def test_gh_not_installed(monkeypatch: MonkeyPatch):
+    mock_which_called = False
+
+    def mock_which(cmd: str) -> str | None:
+        nonlocal mock_which_called
+        mock_which_called = True
+        assert cmd == "gh"
+        return None
+
+    monkeypatch.setattr("shutil.which", mock_which)
+    with pytest.raises(FileNotFoundError):
+        fetch_org_repos(TECH_AI_ORG_NAME, GITHUB_HOSTNAME)
+    assert mock_which_called
+
+
+def test_invalid_json_response(monkeypatch: MonkeyPatch):
+    mock_json_loads_called = False
+
+    def mock_json_loads(_: str):
+        nonlocal mock_json_loads_called
+        mock_json_loads_called = True
+        return {}
+
+    monkeypatch.setattr("json.loads", mock_json_loads)
+    with pytest.raises(APIError) as e:
+        fetch_org_repos(TECH_AI_ORG_NAME, GITHUB_HOSTNAME)
+        assert "JSON response does not match" in e.message
+        assert mock_json_loads_called
+
+
+def test_github_hosted_orgs():
+    repos = fetch_org_repos(TECH_AI_ORG_NAME, GITHUB_HOSTNAME)
+    validate_response(TECH_AI_KNOWN_REPOS, repos)
+
+
+@pytest.mark.xfail(
+    reason="Authentication for self-hosted GitHub instances not yet implemented"
+)
+def test_self_hosted_org():
+    repos = fetch_org_repos(TECH_AI_ORG_NAME, SELF_HOSTED_HOSTNAME)
+    validate_response([], repos)
+
+
+def validate_response(known: list[str], actual: list[Repository]):
+    # check for duplicates
     unique = []
-    for repo in repos:
-        if repo in unique:
-            return False
+    for repo in actual:
+        assert repo not in unique
         unique.append(repo)
-    return True
 
-
-def test_no_duplicates():
-    assert no_duplicates(
-        [
-            Repository("test_repo_1", "https://example.com/test1", "test_org_1"),
-            Repository("test_repo_2", "https://example.com/test2", "test_org_2"),
-        ]
-    )
-    assert not no_duplicates(
-        [
-            Repository("test_repo_1", "https://example.com/test1", "test_org_1"),
-            Repository("test_repo_1", "https://example.com/test1", "test_org_1"),
-        ]
-    )
-
-
-def includes_known_repos(repos: list[Repository], known_repos_names: list[str]) -> bool:
+    # ensure response includes known repositories
     actual_names = []
-    for repo in repos:
+    for repo in actual:
         actual_names.append(repo.name)
-    for known_name in known_repos_names:
-        if known_name not in actual_names:
-            return False
-    return True
+    for repo in known:
+        assert repo in actual_names
 
+    # ensure response excludes .github
+    assert ".github" not in actual_names
 
-def test_includes_known_repos():
-    assert includes_known_repos(
-        [Repository("test_repo_1", "https://example.com/test1", "test_org_1")],
-        ["test_repo_1"],
-    )
-    assert not includes_known_repos(
-        [Repository("test_repo_1", "https://example.com/test1", "test_org_1")],
-        ["test_repo_2"],
-    )
+    # ensure response excludes forks
+    # cannot check currently as gt-tech-ai currently has no public forks

--- a/tests/test_url_tools.py
+++ b/tests/test_url_tools.py
@@ -1,0 +1,54 @@
+import pytest
+from orgwarden.url_tools import validate_url
+
+
+def test_no_url():
+    with pytest.raises(TypeError):
+        validate_url()
+
+
+def test_invalid_urls():
+    INVALID_URLS = [
+        "",  # empty url
+        "github.com/gt-tech-ai/OrgWarden",  # missing protocol
+        "https://gt-tech-ai/OrgWarden"  # missing site
+        "/gt-tech-ai/OrgWarden",  # missing site and protocol
+        "https://github.com/gt-tech-ai/OrgWarden/extra-bits",  # path too long
+    ]
+    for url in INVALID_URLS:
+        with pytest.raises(ValueError):
+            validate_url(url)
+
+
+def test_org_urls():
+    TEST_CASES = [  # url, hostname, org_name
+        ("https://github.com/gt-tech-ai", "github.com", "gt-tech-ai"),
+        ("https://github.gatech.edu/gt-tech-ai", "github.gatech.edu", "gt-tech-ai"),
+    ]
+    for url, hostname, org in TEST_CASES:
+        parsed_url = validate_url(url)
+        assert parsed_url.hostname == hostname
+        assert parsed_url.org_name == org
+        assert parsed_url.repo_name is None
+
+
+def test_repo_urls():
+    TEST_CASES = [  # url, hostname, org_name, repo_name
+        (
+            "https://github.com/gt-tech-ai/OrgWarden",
+            "github.com",
+            "gt-tech-ai",
+            "OrgWarden",
+        ),
+        (
+            "https://github.gatech.edu/gt-tech-ai/OrgWarden",
+            "github.gatech.edu",
+            "gt-tech-ai",
+            "OrgWarden",
+        ),
+    ]
+    for url, hostname, org, repo in TEST_CASES:
+        parsed_url = validate_url(url)
+        assert parsed_url.hostname == hostname
+        assert parsed_url.org_name == org
+        assert parsed_url.repo_name == repo

--- a/uv.lock
+++ b/uv.lock
@@ -107,12 +107,35 @@ wheels = [
 ]
 
 [[package]]
+name = "dbrownell-common"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "inflect" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "typer-config" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/47/040ea5e26408f764ef9a111f5cc91f9dd0985dbde302f72018e66c568648/dbrownell_Common-0.14.4-py3-none-any.whl", hash = "sha256:a082e11cd1e0f125a7b2d275e8ee2410c6abeb92277e2b993b7e02061dfe0a35", size = 41376 },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
+
+[[package]]
+name = "inflect"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/9f/163fbcda011f284d13261f11aa1e14daf28f68729e475c79f7d223c01a36/inflect-4.1.1.tar.gz", hash = "sha256:0527947406025991506b252620da69a5efdc72bf61aa6b4b4976e3bd71c19660", size = 71278 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/9d/81e86c99531ec3dda860f04656e48304cb9dc7d2b9e0ac3e7a806ae5747f/inflect-4.1.1-py3-none-any.whl", hash = "sha256:b0d13bbb6e12313b8fc4a171c86c4f4544cf09a8498e118d25473558200bd171", size = 31507 },
 ]
 
 [[package]]
@@ -150,7 +173,7 @@ name = "orgwarden"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "requests" },
+    { name = "repoauditor" },
     { name = "typer" },
 ]
 
@@ -163,7 +186,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "requests", specifier = ">=2.32.3" },
+    { name = "repoauditor", specifier = ">=0.1.22" },
     { name = "typer", specifier = ">=0.15.2" },
 ]
 
@@ -227,6 +250,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
+]
+
+[[package]]
+name = "repoauditor"
+version = "0.1.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dbrownell-common" },
+    { name = "pluggy" },
+    { name = "requests" },
+    { name = "typer" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/6d/928e676f4c38a24485f1d07859af2ee76f8c51ae38fcad392fe83083b331/RepoAuditor-0.1.22-py3-none-any.whl", hash = "sha256:f5c24e8b3bc2075535c759ad5648147cbd2e87a63ac089487b235b3a3b2387eb", size = 69136 },
 ]
 
 [[package]]
@@ -304,6 +341,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061 },
+]
+
+[[package]]
+name = "typer-config"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/af/78f802bc49eaa5855082cca10e9c9d7d03469c957c149aa159561dc3d744/typer_config-1.4.2.tar.gz", hash = "sha256:69dffc0e06095b57754bfe9fb3e4caf28ab9c2c430dade6433b0ca128510f600", size = 10919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/bd/2e9d407d7ed3f33a40d8211a481b76a0507ba4f117da9dec116c0de9871e/typer_config-1.4.2-py3-none-any.whl", hash = "sha256:b3e1f59bacc8276e5b830f35c9ca403cd85f14173169c23c3756fa816357a34f", size = 11698 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Moved repository listing functionality to dedicated `list-repos` command
    - `list-repos` now accepts a url rather than an org name to allow for self-hosted GitHub instances
- Added `audit` command -> parses the provided url argument into a GitHub repo or org
    - Runs `RepoAuditor` against a specific repo if the url points to a repo
    - Runs `RepoAuditor` against all public, non-forked repos for a specific org if the url points to an org
- Added cli mock testing using `pytest.monkeypatch`
- Reordered CI workflow steps so that faster checks run first
- Various small refactors for code clarity & organization