### PR TITLE
Fix: remove capture parameter from audit_repository

### DIFF
--- a/src/orgwarden/__main__.py
+++ b/src/orgwarden/__main__.py
@@ -65,7 +65,7 @@ def audit(
             url=url,
             org=parsed_url.org_name,
         )
-        exit_code, _ = audit_repository(repo)
+        exit_code = audit_repository(repo)
         sys.exit(exit_code)
 
     else:  # organization
@@ -80,7 +80,7 @@ def audit(
 
         final_exit_code = 0  # keep track of highest exit code i.e. worst error -> ensures the command fails if any repo fails audit
         for repo in repos:
-            exit_code, _ = audit_repository(repo)
+            exit_code = audit_repository(repo)
             final_exit_code = max(final_exit_code, exit_code)
         sys.exit(final_exit_code)
 

--- a/src/orgwarden/audit.py
+++ b/src/orgwarden/audit.py
@@ -2,14 +2,13 @@ import subprocess
 from orgwarden.repo_crawler import Repository
 
 
-def audit_repository(repo: Repository, capture: bool = False) -> tuple[int, str | None]:
+def audit_repository(repo: Repository) -> int:
     """
     Runs RepoAuditor against the specified repository and returns a tuple containing the exit code and the stdout if `capture` is set to True.
     """
     audit_res = subprocess.run(
         f"uv run repo_auditor --include GitHub --GitHub-url {repo.url}",
         shell=True,
-        capture_output=capture,
         text=True,
     )
-    return audit_res.returncode, audit_res.stdout if capture else None
+    return audit_res.returncode

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,5 +1,6 @@
 from orgwarden.audit import audit_repository
 import pytest
+from pytest import CaptureFixture
 
 from orgwarden.repository import Repository
 from tests.constants import ORGWARDEN_REPO_NAME, TECH_AI_ORG_NAME
@@ -10,23 +11,24 @@ def test_no_repository():
         audit_repository()
 
 
-def test_invalid_repository():
-    exit_code, stdout = audit_repository(
+def test_invalid_repository(capfd: CaptureFixture):
+    exit_code = audit_repository(
         Repository(name="invalid-repo", url="https://example.com", org="invalid-org"),
-        capture=True,
     )
     assert exit_code != 0
+    stdout = capfd.readouterr().out
     assert "not a valid GitHub repository" in stdout
 
 
-def test_orgwarden_repo():
+def test_orgwarden_repo(capfd: CaptureFixture):
     repo = Repository(
         name=ORGWARDEN_REPO_NAME,
         url=f"https://github.com/{TECH_AI_ORG_NAME}/{ORGWARDEN_REPO_NAME}",
         org=TECH_AI_ORG_NAME,
     )
-    _, stdout = audit_repository(repo, capture=True)
+    _ = audit_repository(repo)
     # cannot check exit_code, as this is dependent on whether OrgWarden passes audit
+    stdout = capfd.readouterr().out
     assert "Results: DONE!" in stdout
     assert repo.url in stdout
     assert "not a valid GitHub repository" not in stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,16 +82,13 @@ class TestAuditCommand:
         """
         mock_audit_repository_called = False
 
-        def mock_audit_repository(
-            repo: Repository, capture: bool = False
-        ) -> tuple[int, str | None]:
+        def mock_audit_repository(repo: Repository) -> int:
             nonlocal mock_audit_repository_called
             mock_audit_repository_called = True
-            assert not capture
             assert repo.url == ORGWARDEN_URL
             assert repo.name == ORGWARDEN_REPO_NAME
             assert repo.org == TECH_AI_ORG_NAME
-            return 0, None
+            return 0
 
         monkeypatch.setattr(
             "orgwarden.__main__.audit_repository", mock_audit_repository
@@ -124,14 +121,11 @@ class TestAuditCommand:
 
         mock_audit_repository_calls = 0
 
-        def mock_audit_repository(
-            repo: Repository, capture: bool = False
-        ) -> tuple[int, str | None]:
+        def mock_audit_repository(repo: Repository) -> int:
             nonlocal mock_audit_repository_calls
             mock_audit_repository_calls += 1
-            assert not capture
             assert repo.org == TECH_AI_ORG_NAME
-            return 0, None
+            return 0
 
         monkeypatch.setattr(
             "orgwarden.__main__.audit_repository", mock_audit_repository


### PR DESCRIPTION
- Removed `capture` parameter from `audit_repository`
- Introduced `pytest.capfd` fixture to replace `capture` functionality