### PR TITLE
Feature: implement passing GitHub PAT to RepoAuditor via audit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ uv run orgwarden list-repos <org_url>
 ```
 
 ### Audit
-Runs [RepoAuditor](https://github.com/gt-sse-center/RepoAuditor) tooling. If the provided url points to a GitHub repository, RepoAuditor will run against said repository. If the provided url points to a GitHub organization, RepoAuditor will run against all public, non-forked repositories within said organization. 
+Runs [RepoAuditor](https://github.com/gt-sse-center/RepoAuditor) tooling. If the provided url points to a GitHub repository, RepoAuditor will run against said repository. If the provided url points to a GitHub organization, RepoAuditor will run against all public, non-forked repositories within said organization. The `gh-pat` option is a GitHub Personal Access Token (PAT) that is used by RepoAuditor for increased functionality.
+
+*RepoAuditor currently only supports classic PATs.*
 ```bash
-uv run orgwarden audit <repo_or_org_url>
+uv run orgwarden audit <repo_or_org_url> --gh-pat [token]
 ```
 
 

--- a/src/orgwarden/__main__.py
+++ b/src/orgwarden/__main__.py
@@ -1,9 +1,8 @@
-import sys
 from typing import Annotated
 import typer
 from orgwarden.audit import audit_repository
 from orgwarden.repository import Repository
-from orgwarden.repo_crawler import fetch_org_repos
+from orgwarden.repo_crawler import AuthError, fetch_org_repos
 from orgwarden.url_tools import validate_url
 
 app = typer.Typer()
@@ -14,7 +13,8 @@ def list_repos(
     url: Annotated[
         str,
         typer.Argument(
-            help="The url of a GitHub organization. Ex: 'https://github.com/gt-tech-ai'"
+            help="The url of a GitHub organization. Ex: 'https://github.com/gt-tech-ai'",
+            show_default=False,
         ),
     ],
 ) -> None:
@@ -26,16 +26,19 @@ def list_repos(
         parsed_url = validate_url(url)
     except ValueError:
         print_invalid_url_msg(url)
-        sys.exit(1)
+        raise typer.Exit(1)
 
     try:
         repos = fetch_org_repos(parsed_url.org_name, parsed_url.hostname)
     except FileNotFoundError:
         print_gh_not_installed()
-        sys.exit(1)
+        raise typer.Exit(1)
+    except AuthError as e:
+        print_auth_error(e.hostname)
+        raise typer.Exit(1)
     except Exception as e:
-        print(e)
-        sys.exit(1)
+        print_general_error(e)
+        raise typer.Exit(1)
 
     print(f"~~~~~ Public repositories found for {url} ~~~~~")
     for repo in repos:
@@ -45,19 +48,40 @@ def list_repos(
 @app.command()
 def audit(
     url: Annotated[
-        str, typer.Argument(help="The url for a GitHub repository or organization.")
+        str,
+        typer.Argument(
+            help="The url for a GitHub repository or organization. "
+            "If the provided <url> points to a repository, RepoAuditor runs against that repository. "
+            "If the provided <url> points to an organization, RepoAuditor runs against all of that organization's public, non-forked repositories.",
+            show_default=False,
+        ),
     ],
+    gh_pat: Annotated[
+        str | None,
+        typer.Option(
+            help="GitHub Personal Access Token (PAT) - must have access to the specified repository or organization. "
+            "RepoAuditor's full functionality will not be available if a PAT is not provided.",
+            show_default=False,
+        ),
+    ] = None,
 ) -> None:
     """
-    If the provided <url> is a repository, runs RepoAuditor against the specified repository.
-    If the provided <url> is an organization, runs RepoAuditor against all of the organization's public, non-forked repositories.
+    Runs RepoAuditor against the specified organization or repository.
     """
+
+    if gh_pat is None:
+        typer.echo(
+            typer.style(
+                "Running RepoAuditor with limited functionality. Please provide a GitHub PAT for full functionality.",
+                fg=typer.colors.CYAN,
+            )
+        )
 
     try:
         parsed_url = validate_url(url)
     except ValueError:
         print_invalid_url_msg(url)
-        sys.exit(1)
+        raise typer.Exit(1)
 
     if parsed_url.repo_name:  # repository
         repo = Repository(
@@ -65,51 +89,70 @@ def audit(
             url=url,
             org=parsed_url.org_name,
         )
-        exit_code = audit_repository(repo)
-        sys.exit(exit_code)
+        exit_code = audit_repository(repo, gh_pat)
+        raise typer.Exit(exit_code)
 
     else:  # organization
         try:
             repos = fetch_org_repos(parsed_url.org_name, parsed_url.hostname)
         except FileNotFoundError:
             print_gh_not_installed()
-            sys.exit(1)
+            raise typer.Exit(1)
+        except AuthError as e:
+            print_auth_error(e.hostname)
+            raise typer.Exit(1)
         except Exception as e:
-            print(e)
-            sys.exit(1)
+            print_general_error(e)
+            raise typer.Exit(1)
 
         final_exit_code = 0  # keep track of highest exit code i.e. worst error -> ensures the command fails if any repo fails audit
         for repo in repos:
-            exit_code = audit_repository(repo)
+            exit_code = audit_repository(repo, gh_pat)
             final_exit_code = max(final_exit_code, exit_code)
-        sys.exit(final_exit_code)
+        raise typer.Exit(final_exit_code)
 
 
-# pragma: no cover
 def print_invalid_url_msg(url: str):
     typer.echo(
         typer.style(
             f"Error: {url} is invalid.",
             fg=typer.colors.RED,
-        )
+        ),
+        err=True,
     )
     typer.echo(
         typer.style(
             "Example: https://github.com/gt-tech-ai/OrgWarden",
             fg=typer.colors.GREEN,
-        )
+        ),
+        err=True,
     )
 
 
-# pragma: no cover
 def print_gh_not_installed():
-    typer.echo(typer.style("The GitHub CLI is not installed.", fg=typer.colors.RED))
+    typer.echo(
+        typer.style("The GitHub CLI is not installed.", fg=typer.colors.RED), err=True
+    )
     typer.echo(
         typer.style(
             "Please follow the installation instructions here: https://github.com/cli/cli#installation",
             fg=typer.colors.CYAN,
         )
     )
+
+
+def print_auth_error(hostname: str):
+    typer.echo(
+        typer.style(
+            f"Error: could not authenticate with {hostname}. Please ensure the provided token is valid.",
+            fg=typer.colors.RED,
+        ),
+        err=True,
+    )
+
+
+def print_general_error(message: str):
+    typer.echo(typer.style(message, fg=typer.colors.RED), err=True)
 
 
 if __name__ == "__main__":

--- a/src/orgwarden/audit.py
+++ b/src/orgwarden/audit.py
@@ -2,12 +2,20 @@ import subprocess
 from orgwarden.repo_crawler import Repository
 
 
-def audit_repository(repo: Repository) -> int:
+def audit_repository(
+    repo: Repository,
+    gh_pat: str | None,
+) -> int:
     """
-    Runs RepoAuditor against the specified repository and returns a tuple containing the exit code and the stdout if `capture` is set to True.
+    Runs RepoAuditor against the specified repository and returns the resulting exit code.
     """
+
+    command = f"uv run repo_auditor --include GitHub --GitHub-url {repo.url}"
+    if gh_pat is not None:
+        command += f" --GitHub-pat {gh_pat}"
+
     audit_res = subprocess.run(
-        f"uv run repo_auditor --include GitHub --GitHub-url {repo.url}",
+        command,
         shell=True,
         text=True,
     )

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,8 +1,19 @@
-ORGWARDEN_REPO_NAME = "OrgWarden"
-ORGWARDEN_URL = "https://github.com/gt-tech-ai/OrgWarden"
+from orgwarden.repository import Repository
+
 TECH_AI_URL = "https://github.com/gt-tech-ai"
 TECH_AI_ORG_NAME = "gt-tech-ai"
+
+
+ORGWARDEN_REPO_NAME = "OrgWarden"
+ORGWARDEN_URL = "https://github.com/gt-tech-ai/OrgWarden"
+ORGWARDEN_REPO = Repository(
+    name=ORGWARDEN_REPO_NAME,
+    url=f"https://github.com/{TECH_AI_ORG_NAME}/{ORGWARDEN_REPO_NAME}",
+    org=TECH_AI_ORG_NAME,
+)
+
 GITHUB_HOSTNAME = "github.com"
 TECH_AI_KNOWN_REPOS = [ORGWARDEN_REPO_NAME]
 
 SELF_HOSTED_HOSTNAME = "github.gatech.edu"
+SELF_HOSTED_ORG_URL = "https://github.gatech.edu/gt-tech-ai"


### PR DESCRIPTION
- Added `--gh-pat` flag to `audit` command to allow passing GitHub PAT to RepoAuditor
- Cleaned up `Typer` usage