### PR TITLE
Feature: add repository-specific audit settings

### DIFF
--- a/src/orgwarden/audit.py
+++ b/src/orgwarden/audit.py
@@ -14,6 +14,9 @@ def audit_repository(
     if gh_pat is not None:
         command += f" --GitHub-pat {gh_pat}"
 
+    if repo.cli_flags:
+        command += f" {repo.cli_flags}"
+
     audit_res = subprocess.run(
         command,
         shell=True,

--- a/src/orgwarden/audit_settings.py
+++ b/src/orgwarden/audit_settings.py
@@ -1,0 +1,78 @@
+from copy import deepcopy
+import re
+import typer
+from orgwarden.repository import Repository
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RepositorySettings:
+    repo_name: str
+    cli_flags: str
+
+
+SETTINGS_PATTERN = """
+^           # beginning of string
+(?P<key>    # Capture group 'key'
+    [^:]+?) # One or more non-colon characters
+:           # colon separates key & val
+(?P<val>    # Capture group 'val'
+    .+)     # One or more of any character
+$           # end of string
+"""
+SETTINGS_REGEX = re.compile(SETTINGS_PATTERN, re.VERBOSE)
+
+
+def parse_settings_string(value: str) -> RepositorySettings:
+    match = SETTINGS_REGEX.match(value)
+    ERROR = typer.BadParameter(
+        f'Your input: "{value}" does not match pattern expected pattern. Example: "repo_name: --flag-1 --flag-2"',
+        param_hint="settings string",
+    )
+    if not match:
+        raise ERROR
+    key, val = match["key"].strip(), match["val"].strip()
+    if not key or not val:
+        raise ERROR
+
+    return RepositorySettings(key, val)
+
+
+def append_settings(
+    repos: list[Repository], settings: list[RepositorySettings]
+) -> list[Repository]:
+    """
+    Returns a copy of provided `repos` list with `cli_flags` settings appended.
+    """
+    flags_dict: dict[str, str] = {}
+
+    for repo_settings in settings:
+        repo_name, cli_flags = repo_settings.repo_name, repo_settings.cli_flags
+        if repo_name in flags_dict:
+            raise ValueError(
+                f"Repository settings sequence contains multiple entries for {repo_name}."
+            )
+        flags_dict[repo_name] = cli_flags
+
+    copied_repos = deepcopy(repos)
+    for repo in copied_repos:
+        if repo.name in flags_dict:
+            flags = flags_dict[repo.name]
+            if flags:  # skip empty string
+                repo.cli_flags = flags
+
+    # check for unused settings & warn user
+    for repo in copied_repos:
+        if repo.name in flags_dict:
+            del flags_dict[repo.name]
+    if len(flags_dict) != 0:
+        for repo_name in flags_dict.keys():
+            typer.echo(
+                typer.style(
+                    f"Settings for {repo_name} were provided, but this repository is not being audited.",
+                    fg=typer.colors.YELLOW,
+                ),
+                err=True,
+            )
+
+    return copied_repos

--- a/src/orgwarden/repository.py
+++ b/src/orgwarden/repository.py
@@ -3,6 +3,22 @@ from dataclasses import dataclass
 
 @dataclass
 class Repository:
+    """
+    Represents a GitHub repository.
+
+    Attributes
+    __________
+    name : str
+        Repository name
+    url : str
+        Repository URL
+    org : str
+        GitHub organization to which the repo belongs
+    cli_flags : str, optional
+        Single string containing any CLI flags the user wishes to pass to RepoAuditor for this specific repository
+    """
+
     name: str
     url: str
     org: str
+    cli_flags: str | None = None

--- a/tests/test_audit_settings.py
+++ b/tests/test_audit_settings.py
@@ -1,0 +1,110 @@
+import typer
+from orgwarden.repository import Repository
+from orgwarden.audit_settings import (
+    RepositorySettings,
+    parse_settings_string,
+    append_settings,
+)
+import pytest
+from pytest import CaptureFixture
+
+
+class TestParseSettingsString:
+    def test_invalid_settings_strings(self):
+        INVALID_STRINGS = [
+            "",
+            "just_a_key",
+            "key_no_value: ",
+            ": value_no_key",
+            ":",
+        ]
+        for settings_string in INVALID_STRINGS:
+            with pytest.raises(typer.BadParameter):
+                _ = parse_settings_string(settings_string)
+
+    def test_valid_settings_strings(self):
+        TEST_CASES = [  # input, expected
+            ("key: value", RepositorySettings("key", "value")),
+            ("key: multiple values", RepositorySettings("key", "multiple values")),
+            ("repo: --arg-1 --arg-2", RepositorySettings("repo", "--arg-1 --arg-2")),
+            ("repo    :    value", RepositorySettings("repo", "value")),
+            ("too: many: colons", RepositorySettings("too", "many: colons")),
+            (
+                "'quoted_key': 'quoted_val'",
+                RepositorySettings("'quoted_key'", "'quoted_val'"),
+            ),
+            (
+                '"quoted_key": "quoted_val"',
+                RepositorySettings('"quoted_key"', '"quoted_val"'),
+            ),
+            (
+                "repo: --arg-1     --arg-2",
+                RepositorySettings("repo", "--arg-1     --arg-2"),
+            ),
+        ]
+        for settings_string, expected in TEST_CASES:
+            actual = parse_settings_string(settings_string)
+            assert actual == expected
+
+
+class TestAppendSettings:
+    def test_no_mutation(self):
+        REPOS = [
+            Repository(name="repo_1", url="url_1", org="org_1"),
+            Repository(name="repo_2", url="url_2", org="org_2"),
+            Repository(name="repo_3", url="url_3", org="org_3"),
+        ]
+        new_repos = append_settings(REPOS, [])
+        for new_repo, og_repo in zip(new_repos, REPOS):
+            assert new_repo is not og_repo
+
+    def test_raises_with_duplicate_repos(self):
+        REPOSITORY_SETTINGS = [
+            RepositorySettings("repo", "value 1"),
+            RepositorySettings("repo", "value 2"),
+        ]
+        with pytest.raises(ValueError):
+            _ = append_settings([], REPOSITORY_SETTINGS)
+
+    def test_with_no_matching_settings(self):
+        REPOS = [
+            Repository(name="repo_1", url="url_1", org="org_1"),
+            Repository(name="repo_2", url="url_2", org="org_2"),
+            Repository(name="repo_3", url="url_3", org="org_3"),
+        ]
+        REPOSITORY_SETTINGS = [
+            RepositorySettings("non_matching_repo", "--arg-1 --arg-2")
+        ]
+
+        repos_with_settings = append_settings(REPOS, REPOSITORY_SETTINGS)
+        for repo in repos_with_settings:
+            assert repo.cli_flags is None
+
+    def test_added_settings(self):
+        REPOS = [
+            Repository(name="repo_1", url="url_1", org="org_1"),
+            Repository(name="repo_2", url="url_2", org="org_2"),
+            Repository(name="repo_3", url="url_3", org="org_3"),
+        ]
+        REPOSITORY_SETTINGS = [
+            RepositorySettings("repo_1", "--arg-1 --arg-2"),
+            RepositorySettings("repo_2", "--arg-3"),
+            RepositorySettings("repo_3", "--arg-1 --arg-2 --arg-3"),
+        ]
+        repos_with_settings = append_settings(REPOS, REPOSITORY_SETTINGS)
+        for repo, repo_settings in zip(repos_with_settings, repos_with_settings):
+            assert repo.name == repo_settings.name
+            assert repo.cli_flags == repo_settings.cli_flags
+
+    def test_empty_flags(self):
+        REPOS = [Repository(name="repo", url="url", org="org")]
+        REPOSITORY_SETTINGS = [RepositorySettings("repo", "")]
+        repos_with_settings = append_settings(REPOS, REPOSITORY_SETTINGS)
+        for repo in repos_with_settings:
+            assert repo.cli_flags is None
+
+    def test_unused_settings(self, capfd: CaptureFixture):
+        REPOSITORY_SETTINGS = [RepositorySettings("repo", "--arg")]
+        _ = append_settings([], REPOSITORY_SETTINGS)
+        stderr = capfd.readouterr().err
+        assert "repository is not being audited" in stderr


### PR DESCRIPTION
- added `--settings` flag to audit command - allows passing a JSON string containing repository specific audit settings
    - JSON string is validated in `audit_settings.py` and appended to `Repository` objects
    - repository-specific CLI flags are now passed to RepoAuditor in `audit_repository` function
- added documentation and tests for above