### PR TITLE
Refactor: clean up unit tests & other enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ uv run orgwarden list-repos [org_url]
 ### Audit
 Runs [RepoAuditor](https://github.com/gt-sse-center/RepoAuditor) tooling. If the required `url` argument points to a GitHub repository, RepoAuditor will run against said repository. If the url points to a GitHub organization, RepoAuditor will run against all public, non-forked repositories within said organization.
 
-The optional `settings` argument allows you to alter audit behavior on an individual repository basis by providing a sequence of settings strings. See [Repository-Specific Settings](#repository-specific-settings) for more information.
+The optional `settings_sequence` argument allows you to alter audit behavior on an individual repository basis by providing a sequence of settings strings. See [Repository-Specific Settings](#repository-specific-settings) for more information.
 
 The `gh-pat` flag allows you to pass a GitHub Personal Access Token to RepoAuditor and is required for full funcionality. See [Setting Up a Personal Access Token](#setting-up-a-personal-access-token) for more information.
 
 **Note** - If a PAT is not provided, `audit` will run with limited functionality **and will always exit with a non-zero exit code.**
 
 ```bash
-uv run orgwarden audit [repo_or_org_url] [settings]... --gh-pat <token>
+uv run orgwarden audit [repo_or_org_url] [settings_sequence]... --gh-pat <token>
 ```
 
 

--- a/src/orgwarden/audit.py
+++ b/src/orgwarden/audit.py
@@ -4,6 +4,7 @@ from orgwarden.repo_crawler import Repository
 
 def audit_repository(
     repo: Repository,
+    audit_settings: dict[str, str] | None,
     gh_pat: str | None,
 ) -> int:
     """
@@ -14,8 +15,8 @@ def audit_repository(
     if gh_pat is not None:
         command += f" --GitHub-pat {gh_pat}"
 
-    if repo.cli_flags:
-        command += f" {repo.cli_flags}"
+    if audit_settings and repo.name in audit_settings:
+        command += f" {audit_settings[repo.name]}"
 
     audit_res = subprocess.run(
         command,

--- a/src/orgwarden/repo_crawler.py
+++ b/src/orgwarden/repo_crawler.py
@@ -26,6 +26,11 @@ def fetch_org_repos(
     Raises a `FileNotFoundError` if the GitHub CLI is not installed.
     """
 
+    if not org_name:
+        raise ValueError("org_name is an empty string.")
+    if not hostname:
+        raise ValueError("hostname is an empty string.")
+
     # check if gh cli is installed
     if shutil.which("gh") is None:
         raise FileNotFoundError("GitHub CLI is not installed.")

--- a/src/orgwarden/repository.py
+++ b/src/orgwarden/repository.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class Repository:
     """
     Represents a GitHub repository.
@@ -14,11 +14,8 @@ class Repository:
         Repository URL
     org : str
         GitHub organization to which the repo belongs
-    cli_flags : str, optional
-        Single string containing any CLI flags the user wishes to pass to RepoAuditor for this specific repository
     """
 
     name: str
     url: str
     org: str
-    cli_flags: str | None = None

--- a/src/orgwarden/typer_print_functions.py
+++ b/src/orgwarden/typer_print_functions.py
@@ -1,0 +1,54 @@
+import typer
+
+
+def print_general_error(message: str):
+    typer.echo(typer.style(message, fg=typer.colors.RED), err=True)
+
+
+def print_invalid_url_msg(message: str):
+    typer.echo(
+        typer.style(
+            message,
+            fg=typer.colors.RED,
+        ),
+        err=True,
+    )
+    typer.echo(
+        typer.style(
+            "Example: https://github.com/gt-tech-ai/OrgWarden",
+            fg=typer.colors.GREEN,
+        ),
+        err=True,
+    )
+
+
+def print_gh_not_installed():
+    typer.echo(
+        typer.style("The GitHub CLI is not installed.", fg=typer.colors.RED), err=True
+    )
+    typer.echo(
+        typer.style(
+            "Please follow the installation instructions here: https://github.com/cli/cli#installation",
+            fg=typer.colors.CYAN,
+        )
+    )
+
+
+def print_auth_error(hostname: str):
+    typer.echo(
+        typer.style(
+            f"Error: could not authenticate with {hostname}. Please ensure the provided token is valid.",
+            fg=typer.colors.RED,
+        ),
+        err=True,
+    )
+
+
+def print_unused_settings_warning(repo_name: str):
+    typer.echo(
+        typer.style(
+            f"Settings for {repo_name} were provided, but this repository is not being audited.",
+            fg=typer.colors.YELLOW,
+        ),
+        err=True,
+    )

--- a/src/orgwarden/url_tools.py
+++ b/src/orgwarden/url_tools.py
@@ -15,14 +15,18 @@ def validate_url(url: str) -> ParsedURL:
     Returns a `ParsedURL` object if the url is valid.
     Raises a ValueError if the url is invalid.
     """
+    invalid_url_error = ValueError(f"{url} is not a valid URL.")
 
     parsed_url = urlparse(url)
     if not parsed_url.scheme or not parsed_url.netloc:
-        raise ValueError()
+        raise invalid_url_error
 
     split_path = parsed_url.path.strip("/").split("/")
     if len(split_path) != 1 and len(split_path) != 2:
-        raise ValueError()
+        raise invalid_url_error
+    if len(split_path) == 1:  # urls with no path will sometimes parse path as ['']
+        if not split_path[0]:
+            raise invalid_url_error
 
     return ParsedURL(
         hostname=parsed_url.netloc,

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -14,6 +14,3 @@ ORGWARDEN_REPO = Repository(
 
 GITHUB_HOSTNAME = "github.com"
 TECH_AI_KNOWN_REPOS = [ORGWARDEN_REPO_NAME]
-
-SELF_HOSTED_HOSTNAME = "github.gatech.edu"
-SELF_HOSTED_ORG_URL = "https://github.gatech.edu/gt-tech-ai"

--- a/tests/test_audit_settings.py
+++ b/tests/test_audit_settings.py
@@ -1,12 +1,10 @@
 import typer
-from orgwarden.repository import Repository
 from orgwarden.audit_settings import (
-    RepositorySettings,
+    RepoAuditSettings,
     parse_settings_string,
-    append_settings,
+    get_audit_settings,
 )
 import pytest
-from pytest import CaptureFixture
 
 
 class TestParseSettingsString:
@@ -19,27 +17,29 @@ class TestParseSettingsString:
             ":",
         ]
         for settings_string in INVALID_STRINGS:
-            with pytest.raises(typer.BadParameter):
+            with pytest.raises(
+                typer.BadParameter, match="does not match expected pattern"
+            ):
                 _ = parse_settings_string(settings_string)
 
     def test_valid_settings_strings(self):
         TEST_CASES = [  # input, expected
-            ("key: value", RepositorySettings("key", "value")),
-            ("key: multiple values", RepositorySettings("key", "multiple values")),
-            ("repo: --arg-1 --arg-2", RepositorySettings("repo", "--arg-1 --arg-2")),
-            ("repo    :    value", RepositorySettings("repo", "value")),
-            ("too: many: colons", RepositorySettings("too", "many: colons")),
+            ("key: value", RepoAuditSettings("key", "value")),
+            ("key: multiple values", RepoAuditSettings("key", "multiple values")),
+            ("repo: --arg-1 --arg-2", RepoAuditSettings("repo", "--arg-1 --arg-2")),
+            ("repo    :    value", RepoAuditSettings("repo", "value")),
+            ("too: many: colons", RepoAuditSettings("too", "many: colons")),
             (
                 "'quoted_key': 'quoted_val'",
-                RepositorySettings("'quoted_key'", "'quoted_val'"),
+                RepoAuditSettings("'quoted_key'", "'quoted_val'"),
             ),
             (
                 '"quoted_key": "quoted_val"',
-                RepositorySettings('"quoted_key"', '"quoted_val"'),
+                RepoAuditSettings('"quoted_key"', '"quoted_val"'),
             ),
             (
                 "repo: --arg-1     --arg-2",
-                RepositorySettings("repo", "--arg-1     --arg-2"),
+                RepoAuditSettings("repo", "--arg-1     --arg-2"),
             ),
         ]
         for settings_string, expected in TEST_CASES:
@@ -47,64 +47,27 @@ class TestParseSettingsString:
             assert actual == expected
 
 
-class TestAppendSettings:
-    def test_no_mutation(self):
-        REPOS = [
-            Repository(name="repo_1", url="url_1", org="org_1"),
-            Repository(name="repo_2", url="url_2", org="org_2"),
-            Repository(name="repo_3", url="url_3", org="org_3"),
-        ]
-        new_repos = append_settings(REPOS, [])
-        for new_repo, og_repo in zip(new_repos, REPOS):
-            assert new_repo is not og_repo
-
+class TestGetAuditSettings:
     def test_raises_with_duplicate_repos(self):
         REPOSITORY_SETTINGS = [
-            RepositorySettings("repo", "value 1"),
-            RepositorySettings("repo", "value 2"),
+            RepoAuditSettings("repo", "value 1"),
+            RepoAuditSettings("repo", "value 2"),
         ]
-        with pytest.raises(ValueError):
-            _ = append_settings([], REPOSITORY_SETTINGS)
-
-    def test_with_no_matching_settings(self):
-        REPOS = [
-            Repository(name="repo_1", url="url_1", org="org_1"),
-            Repository(name="repo_2", url="url_2", org="org_2"),
-            Repository(name="repo_3", url="url_3", org="org_3"),
-        ]
-        REPOSITORY_SETTINGS = [
-            RepositorySettings("non_matching_repo", "--arg-1 --arg-2")
-        ]
-
-        repos_with_settings = append_settings(REPOS, REPOSITORY_SETTINGS)
-        for repo in repos_with_settings:
-            assert repo.cli_flags is None
-
-    def test_added_settings(self):
-        REPOS = [
-            Repository(name="repo_1", url="url_1", org="org_1"),
-            Repository(name="repo_2", url="url_2", org="org_2"),
-            Repository(name="repo_3", url="url_3", org="org_3"),
-        ]
-        REPOSITORY_SETTINGS = [
-            RepositorySettings("repo_1", "--arg-1 --arg-2"),
-            RepositorySettings("repo_2", "--arg-3"),
-            RepositorySettings("repo_3", "--arg-1 --arg-2 --arg-3"),
-        ]
-        repos_with_settings = append_settings(REPOS, REPOSITORY_SETTINGS)
-        for repo, repo_settings in zip(repos_with_settings, repos_with_settings):
-            assert repo.name == repo_settings.name
-            assert repo.cli_flags == repo_settings.cli_flags
+        with pytest.raises(ValueError, match="multiple entries for"):
+            _ = get_audit_settings(REPOSITORY_SETTINGS)
 
     def test_empty_flags(self):
-        REPOS = [Repository(name="repo", url="url", org="org")]
-        REPOSITORY_SETTINGS = [RepositorySettings("repo", "")]
-        repos_with_settings = append_settings(REPOS, REPOSITORY_SETTINGS)
-        for repo in repos_with_settings:
-            assert repo.cli_flags is None
+        REPOSITORY_SETTINGS = [RepoAuditSettings("repo", "")]
+        audit_settings = get_audit_settings(REPOSITORY_SETTINGS)
+        assert len(audit_settings) == 0
 
-    def test_unused_settings(self, capfd: CaptureFixture):
-        REPOSITORY_SETTINGS = [RepositorySettings("repo", "--arg")]
-        _ = append_settings([], REPOSITORY_SETTINGS)
-        stderr = capfd.readouterr().err
-        assert "repository is not being audited" in stderr
+    def test_dict_built_correctly(self):
+        REPO_AUDIT_SETTINGS = [
+            RepoAuditSettings("repo_1", "--arg-1 --arg-2"),
+            RepoAuditSettings("repo_2", "--arg-3"),
+            RepoAuditSettings("repo_3", "--arg-1 --arg-2 --arg-3"),
+        ]
+        audit_settings = get_audit_settings(REPO_AUDIT_SETTINGS)
+        for setting in REPO_AUDIT_SETTINGS:
+            assert setting.repo_name in audit_settings
+            assert audit_settings[setting.repo_name] == setting.cli_flags

--- a/tests/test_url_tools.py
+++ b/tests/test_url_tools.py
@@ -2,22 +2,18 @@ import pytest
 from orgwarden.url_tools import validate_url
 
 
-def test_no_url():
-    with pytest.raises(TypeError):
-        validate_url()
-
-
 def test_invalid_urls():
     INVALID_URLS = [
         "",  # empty url
         "github.com/gt-tech-ai/OrgWarden",  # missing protocol
-        "https://gt-tech-ai/OrgWarden"  # missing site
+        "https://gt-tech-ai/OrgWarden"  # missing top-level domain
         "/gt-tech-ai/OrgWarden",  # missing site and protocol
         "https://github.com/gt-tech-ai/OrgWarden/extra-bits",  # path too long
+        "https://github.com",  # no path
     ]
     for url in INVALID_URLS:
-        with pytest.raises(ValueError):
-            validate_url(url)
+        with pytest.raises(ValueError, match="not a valid URL"):
+            _ = validate_url(url)
 
 
 def test_org_urls():


### PR DESCRIPTION
# Test Refactor & General Cleanup
Core functionality remains Identical
Reached 100% test coverage 🎉

## General Changes
- moved printing helper functions from `__main__.py` to dedicated `typer_print_functions.py` file
- remove `cli_flags` attribute from `Repository` class & refactored repository-specific settings logic as needed - results in a much cleaner and more decoupled architecture

## Testing Refactor
- used `lambda` for `monkeypatch` mocking where appropriate to simplify tests and reduce boilerplate
- tests with `pytest.raises` now check error message in addition to exception type
- reworked `test_cli.py`
    - start by exercising the "happy path"
    - address specific edge cases as needed for coverage
    - removed redundant tests for logic already addressed in other test files