### PR TITLE
Feature: add --module flag to specify RepoAuditor modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ The `gh-pat` argument is a GitHub Personal Access Token (PAT) that is used to ac
 
 The optional `settings_sequence` argument allows you to alter audit behavior on an individual repository basis by providing a sequence of settings strings. See [Repository-Specific Settings](#repository-specific-settings) for more information.
 
+The optional `--module` flag allows you to specify which RepoAuditor modules you would like to include in the audit. All available modules will run if none are specified. See [RepoAuditor docs](https://github.com/gt-sse-center/RepoAuditor) for more information on available modules.
+
 ```bash
-uv run orgwarden audit [repo_or_org_url] [gh_pat] [settings_sequence]...
+uv run orgwarden audit [repo_or_org_url] [gh_pat] [settings_sequence]... --module <module_1> --module <module_2>
 ```
 
 
@@ -129,6 +131,7 @@ You can use our action with the following inputs:
 | ----- | -------- | ----------- |
 | org-url | yes | Full URL of the GitHub organization you would like to audit. |
 | github-pat | yes | Your GitHub Personal Access Token (PAT). Store your token as a [GitHub Actions Secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). |
+| modules | no | Specific RepoAuditor modules to run, separated by a space. |
 | repository-audit-settings | no | Sequence of repository-specific audit settings. |
 
 ### Example: Using OrgWarden in a Workflow
@@ -148,6 +151,7 @@ jobs:
         with:
           org-url: https://github.com/my-org
           github-pat: ${{ secrets.ORGWARDEN_AUDIT_PAT }}
+          modules: GitHub GitHub-Customization
           repository-audit-settings: >
             "my-awesome-repo: --GitHub-AutoMerge-false --GitHub-License-value MIT"
             "secret-internal-tool: --GitHub-SupportProjects-false"

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,13 @@ inputs:
       A GitHub Personal Access Token (PAT).
       See https://github.com/gt-tech-ai/OrgWarden#setting-up-a-personal-access-token for help.
     required: true
+  modules:
+    description: |
+      The RepoAuditor modules you would like to run. If not provided, OrgWarden will run all RepoAuditor modules.
+      Modules should be deliminated by a single space.
+      Example: "GitHub My-Module GitHub-Customization"
+      See https://github.com/gt-sse-center/RepoAuditor for available modules.
+    required: False
   repository-audit-settings:
     description: |
       Allows you to alter audit behavior on an individual repository basis by providing a sequence of settings strings.
@@ -45,7 +52,16 @@ runs:
         # OrgWarden
         CYAN="\033[0;36m"
         echo -e "${CYAN}Now Running OrgWarden"
+        
+        command="uv run orgwarden audit ${{ inputs.org-url }} ${{ inputs.github-pat }} ${{ inputs.repository-audit-settings }}"
+        
+        if [ -n "${{ inputs.modules }}" ]; then
+          modules=(${{ inputs.modules }})
+          for module in "${modules[@]}"; do
+            command+=" --module $module"
+          done
+        fi
 
-        uv run orgwarden audit ${{ inputs.org-url }} ${{ inputs.github-pat }} ${{ inputs.repository-audit-settings }}
+        eval "$command"
       shell: bash
       

--- a/src/orgwarden/__main__.py
+++ b/src/orgwarden/__main__.py
@@ -98,6 +98,16 @@ def audit(
             show_default=False,
         ),
     ] = None,
+    modules: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--module",
+            help="The RepoAuditor modules you would like to run. Defaults to all modules. "
+            "Can be provided multiple times. Example: '--module GitHub --module GitHub-Customization'. "
+            "See [RepoAuditor docs](https://github.com/gt-sse-center/RepoAuditor) for available modules.",
+            show_default=False,
+        ),
+    ] = None,
 ) -> None:
     """
     Runs RepoAuditor against the specified organization or repository.
@@ -149,7 +159,7 @@ def audit(
     for repo in repos:
         typer.echo(typer.style(f"Now Auditing: {repo.url}", fg=typer.colors.CYAN))
 
-        exit_code = audit_repository(repo, gh_pat, audit_settings)
+        exit_code = audit_repository(repo, gh_pat, audit_settings, modules)
         final_exit_code = max(final_exit_code, exit_code)
     raise typer.Exit(final_exit_code)
 

--- a/src/orgwarden/audit.py
+++ b/src/orgwarden/audit.py
@@ -1,17 +1,22 @@
 import subprocess
 from orgwarden.repo_crawler import Repository
 
+KNOWN_MODULES = ["GitHub"]
+
 
 def audit_repository(
     repo: Repository,
     gh_pat: str,
     audit_settings: dict[str, str] | None,
+    modules: list[str] | None,
 ) -> int:
     """
     Runs RepoAuditor against the specified repository and returns the resulting exit code.
     """
+    if not modules:
+        modules = KNOWN_MODULES
 
-    command = f"uv run repo_auditor --include GitHub --GitHub-url {repo.url} --GitHub-pat {gh_pat}"
+    command = f"uv run repo_auditor {' '.join(f'--include {module}' for module in modules)} --GitHub-url {repo.url} --GitHub-pat {gh_pat}"
 
     if audit_settings and repo.name in audit_settings:
         command += f" {audit_settings[repo.name]}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -144,7 +144,7 @@ class TestAuditCommand:
 
         monkeypatch.setattr(get_audit_settings_IMPORT_PATH, mock_get_audit_settings)
 
-        def mock_audit(_repo: Repository, _gh_pat: str, audit_settings: dict[str, str]):
+        def mock_audit(_repo, _gh_pat, audit_settings: dict[str, str], *args, **kwargs):
             assert audit_settings == EXPECTED_AUDIT_SETTINGS
             return 0
 
@@ -153,4 +153,25 @@ class TestAuditCommand:
             app, [self.COMMAND, TECH_AI_URL, GITHUB_PAT, *SETTINGS_SEQUENCE]
         )
         assert mock_get_audit_settings_called
+        assert res.exit_code == 0
+
+    def test_modules_flag(self, monkeypatch: MonkeyPatch):
+        def mock_audit(_repo, _gh_pat, _audit_settings, modules: list[str]):
+            assert "module-1" in modules
+            assert "module-2" in modules
+            return 0
+
+        monkeypatch.setattr(audit_repository_IMPORT_PATH, mock_audit)
+        res = runner.invoke(
+            app,
+            [
+                self.COMMAND,
+                TECH_AI_URL,
+                GITHUB_PAT,
+                "--module",
+                "module-1",
+                "--module",
+                "module-2",
+            ],
+        )
         assert res.exit_code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -188,7 +188,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "repoauditor", specifier = ">=0.1.24,<1.0.0" },
+    { name = "repoauditor", specifier = ">=0.1.24" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "typer", specifier = ">=0.15.2" },
 ]


### PR DESCRIPTION
As RepoAuditor currently only provides the GitHub module, this change is not strictly necessary. However, I'd like to future-proof OrgWarden as more modules will be added to RepoAuditor.

- added optional `--module` flag to `audit` command
    - users can specify which RepoAuditor modules they would like to run
    - defaults to all RepoAuditor modules
- added `modules` as optional input to composite action
- documentation for above