### PR TITLE
Enhancement: ensure tags update on each commit

### DIFF
--- a/.github/update_tags.sh
+++ b/.github/update_tags.sh
@@ -1,0 +1,34 @@
+parse_and_add_tags() {
+    tag="$1"
+
+    # validate tag and capture major/minor/patch
+    if [[ ! "$tag" =~ ^([^0-9]*)([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        echo "Invalid semantic version tag: $tag" >&2
+        exit 1
+    fi
+    prefix="${BASH_REMATCH[1]}"
+    major="${BASH_REMATCH[2]}"
+    minor="${BASH_REMATCH[3]}"
+    patch="${BASH_REMATCH[4]}"
+
+    # create new tags
+    major_tag="${prefix}${major}"
+    minor_tag="${prefix}${major}.${minor}"
+    patch_tag="${prefix}${major}.${minor}.${patch}"
+
+    # apply tags
+    git tag "$major_tag" -f
+    git tag "$minor_tag" -f
+    git tag "$patch_tag" # shouldn't have to force, if we do, something has gone wrong
+}
+
+# update package tags
+package_tag=$(uv run autogitsemver src --no-branch-name --no-metadata --quiet)
+parse_and_add_tags "$package_tag"
+
+# update action tags
+action_tag=$(uv run autogitsemver action-version --no-branch-name --no-metadata --quiet)
+parse_and_add_tags "$action_tag"
+
+# push tags
+git push --tags --force

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,24 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Update-SemVer-Tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install AutoGitSemVer
+        run: uv add AutoGitSemVer
+
+      - name: Update Package & Action Major/Minor/Patch Tags
+        run: .github/update_tags.sh

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ jobs:
   Run-OrgWarden:
     runs-on: ubuntu-latest
     steps:
-      - uses: gt-tech-ai/OrgWarden@v0
+      - uses: gt-tech-ai/OrgWarden@action-v0
         with:
           org-url: https://github.com/my-org
           github-pat: ${{ secrets.ORGWARDEN_AUDIT_PAT }}
@@ -164,3 +164,4 @@ To manually run tests on this project, run the following command:
 ```bash
 uv run pytest
 ```
+OrgWarden uses [AutoGitSemVer](https://github.com/davidbrownell/AutoGitSemVer) to automatically update semantic version tags. If your changes introduce a *backwards-compatible* feature, please include "+minor" in your commit message's title or description. If your changes introduce a *backwards-incompatible* feature, please include "+major" in your commit message's title or description.

--- a/action-version/AutoGitSemVer.yml
+++ b/action-version/AutoGitSemVer.yml
@@ -1,0 +1,3 @@
+version_prefix: action-v
+additional_dependencies:
+  - "../action.yml"

--- a/action-version/README.md
+++ b/action-version/README.md
@@ -1,0 +1,7 @@
+# `action-version`
+
+OrgWarden maintains two sets of semantic version tags - one for the [OrgWarden CLI tool](../src) (ex: `v0.1.2`), and one for the [OrgWarden composite action](../action.yml) (ex: `action-v0.2.3`).
+
+The [CD workflow](../.github/workflows/CD.yml) uses [`AutoGitSemVer`](https://github.com/davidbrownell/AutoGitSemVer) to analyze changes to the CLI & composite action source code and independently update their respective tags accordingly. Due to a quirk with `AutoGitSemVer`, this `action-version` directory is required in order to analyze changes to the `action.yml` file. As such, this directory should not contain any files other than this `README.md` and the [`AutoGitSemVer.yml`](./AutoGitSemVer.yml) configuration file.
+
+For context on how this directory is used with `AutoGitSemVer`, see the [`update_tags.sh` script](../.github/update_tags.sh).

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: gt-tech-ai/OrgWarden
+        ref: v0
 
     - name: Setup uv
       uses: astral-sh/setup-uv@v5

--- a/src/AutoGitSemVer.yml
+++ b/src/AutoGitSemVer.yml
@@ -1,0 +1,5 @@
+version_prefix: v
+additional_dependencies:
+  - "../pyproject.toml"
+  - "../README.md"
+  - "../uv.lock"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,6 @@ class TestAuditCommand:
             _ = runner.invoke(app, [self.COMMAND, url, GITHUB_PAT])
             stdout = capfd.readouterr().out
             assert "DONE" in stdout
-            assert url in stdout
 
     def test_handles_unused_settings_entries(
         self, monkeypatch: MonkeyPatch, capfd: CaptureFixture


### PR DESCRIPTION
We should use a version tag to specify an OrgWarden composite action release - i.e. `uses: gt-tech-ai/OrgWarden@v0`, rather than targeting the main branch, i.e. `uses: gt-tech-ai/OrgWarden@main`.

Unfortunately, GitHub does not automatically resolve `@v0` to the latest sem-ver tag, such as `v0.1.12`.

The added `CD.yml` workflow will update the `v0` tag to the latest commit whenever changes are pushed to `main`. If breaking changes are introduced in the future, the workflow can be edited to update a `v1`/`v2`/etc.. tag instead.