### PR TITLE
Fix: preserve both single & double quotes in action inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,15 +60,16 @@ runs:
       shell: bash
 
     - name: Run OrgWarden
+      env:
+        # Must be converted to an enviroment variable in order to preserve single and double quotes
+        REPO_AUDIT_SETTINGS: ${{ inputs.repository-audit-settings }}
       run: |
         # OrgWarden
         CYAN="\033[0;36m"
         echo -e "${CYAN}Now Running OrgWarden"
+        
+        command="uv run orgwarden audit ${{ inputs.org-url }} ${{ inputs.github-pat }} $REPO_AUDIT_SETTINGS"
 
-        repo_settings='${{ inputs.repository-audit-settings }}'
-        
-        command="uv run orgwarden audit ${{ inputs.org-url }} ${{ inputs.github-pat }} $repo_settings"
-        
         if echo "${{ inputs.include-all-private-repos }}" | grep -i "true"; then
           command+=" --include-all-private-repos"
         elif [ -n "${{ inputs.included-private-repos }}" ]; then


### PR DESCRIPTION
The [previous fix](https://github.com/gt-tech-ai/OrgWarden/pull/27) to the composite action preserved double quotes in action inputs.
However, this fix did not preserve single quotes in action inputs.
When running the action with a `repository-audit-settings` value of `"repo: --GitHub-License-value '' --other-flag"`, the action parsed this input as `"repo: --GitHub-License-value --other-flag"`, causing the action to fail.

This change ensures that both double *and* single quotes are preserved.