### PR TITLE
Fix: remove quotes in action eval statement

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,6 @@ runs:
         fi
 
         echo Running Command: $command
-        eval "$command"
+        eval $command
       shell: bash
       


### PR DESCRIPTION
And one final fix... The previous two changes fixed how the `audit-repository-settings` input is parsed in the composite action. However, quoting the `$command` variable in the final `eval "$command"` line causes issues in [some edge cases](https://github.com/gt-tech-ai/.github/actions/runs/14892212230/job/41826883812).

Unquoting `$command` fixes this issue and ensures the entirety of the correctly parsed command string is executed.

(I hate bash.)